### PR TITLE
Add Mem0 client cleanup

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -8,7 +8,7 @@ import asyncio
 import json
 import os
 
-from utils import get_mem0_client
+from utils import get_mem0_client, close_mem0_client
 
 load_dotenv()
 
@@ -42,8 +42,8 @@ async def mem0_lifespan(server: FastMCP) -> AsyncIterator[Mem0Context]:
     try:
         yield Mem0Context(memory_client=memory_client, notes_client=notes_client)
     finally:
-        # No explicit cleanup needed for the Mem0 client
-        pass
+        close_mem0_client(memory_client)
+        close_mem0_client(notes_client)
 
 # Initialize FastMCP server with the Mem0 client as context
 mcp = FastMCP(

--- a/src/utils.py
+++ b/src/utils.py
@@ -100,3 +100,39 @@ def get_mem0_client(collection_name: str = "mem0_memories"):
     
     # Create and return the Memory client
     return Memory.from_config(config)
+
+
+def close_mem0_client(client: Memory) -> None:
+    """Attempt to gracefully close a Mem0 client and its resources."""
+    if client is None:
+        return
+
+    # Try common close semantics on the client itself
+    for method_name in ("close", "dispose", "shutdown"):
+        close_method = getattr(client, method_name, None)
+        if callable(close_method):
+            try:
+                close_method()
+            except Exception:
+                pass
+
+    # Attempt to close nested objects such as vector stores or DB pools
+    vector_store = getattr(client, "vector_store", None)
+    if vector_store is not None:
+        for method_name in ("close", "dispose", "shutdown"):
+            close_method = getattr(vector_store, method_name, None)
+            if callable(close_method):
+                try:
+                    close_method()
+                except Exception:
+                    pass
+
+        db = getattr(vector_store, "db", None)
+        if db is not None:
+            for method_name in ("close", "dispose", "shutdown"):
+                close_method = getattr(db, method_name, None)
+                if callable(close_method):
+                    try:
+                        close_method()
+                    except Exception:
+                        pass


### PR DESCRIPTION
## Summary
- cleanup Mem0 connections on shutdown
- implement `close_mem0_client` helper to close underlying vector store resources

## Testing
- `python -m py_compile src/*.py`
