### PR TITLE
Fix memory config for new mem0 versions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,7 +40,3 @@ EMBEDDING_MODEL_CHOICE=
 # For Supabase Postgres connection, you can find this in "Connect" (top middle of Supabase dashboard) -> Transaction pooler
 DATABASE_URL=
 
-# Optional SQLAlchemy connection pool settings
-# Adjust these if you encounter 'too many clients' errors
-DB_POOL_SIZE=5
-DB_MAX_OVERFLOW=0

--- a/README.md
+++ b/README.md
@@ -87,8 +87,6 @@ The following environment variables can be configured in your `.env` file:
 | `LLM_CHOICE` | LLM model to use | `gpt-4o-mini` |
 | `EMBEDDING_MODEL_CHOICE` | Embedding model to use | `text-embedding-3-small` |
 | `DATABASE_URL` | PostgreSQL connection string | `postgresql://user:pass@host:port/db` |
-| `DB_POOL_SIZE` | SQLAlchemy pool size for DB connections | `5` |
-| `DB_MAX_OVERFLOW` | Additional connections beyond the pool size | `0` |
 
 Make sure to use the `postgresql://` scheme exactly—`postgres://` will fail validation.
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -87,16 +87,12 @@ def get_mem0_client(collection_name: str = "mem0_memories"):
             config["embedder"]["config"]["ollama_base_url"] = embedding_base_url
     
     # Configure Supabase vector store
-    pool_size = int(os.getenv("DB_POOL_SIZE", "5"))
-    max_overflow = int(os.getenv("DB_MAX_OVERFLOW", "0"))
     config["vector_store"] = {
         "provider": "supabase",
         "config": {
             "connection_string": os.environ.get('DATABASE_URL', ''),
             "collection_name": collection_name,
             "embedding_model_dims": 1536 if llm_provider == "openai" else 768,
-            "pool_size": pool_size,
-            "max_overflow": max_overflow,
         }
     }
 


### PR DESCRIPTION
## Summary
- stop including unsupported SQLAlchemy pooling options in the Mem0 config
- update README and `.env.example` to remove references to the removed options

## Testing
- `pytest -q`